### PR TITLE
Remove circular references

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "d3": "^3.5.6",
     "d3tooltip": "^1.2.2",
     "deepmerge": "^0.2.10",
+    "fclone": "^1.0.7",
     "is-plain-object": "2.0.1",
     "json-pretty": "0.0.1",
     "map2tree": "^1.4.0",

--- a/src/charts/tree/sortAndSerialize.js
+++ b/src/charts/tree/sortAndSerialize.js
@@ -1,5 +1,6 @@
 import { is } from 'ramda'
 import isPlainObject from 'is-plain-object'
+import fclone from 'fclone';
 
 function isSerializable(obj) {
   if (obj === undefined || obj === null || is(Boolean, obj) || is(Number, obj) || is(String, obj)) {
@@ -44,5 +45,5 @@ function sortObject(obj, strict) {
 }
 
 export default function sortAndSerialize(obj) {
-  return JSON.stringify(sortObject(obj, true), undefined, 2)
+  return JSON.stringify(sortObject(fclone(obj), true), undefined, 2)
 }


### PR DESCRIPTION
Having circular references, it would either hang the browser or show `not serializable` error. Removing them helps.
