### PR TITLE
Animate the updated nodes

### DIFF
--- a/src/charts/tree/tree.js
+++ b/src/charts/tree/tree.js
@@ -240,6 +240,9 @@ export default function(DOMNode, options = {}) {
       // fade the text in
       nodeUpdate.select('text')
         .style('fill-opacity', 1)
+      
+      // restore the circle
+      nodeUpdate.select('circle').attr('r', 7)
 
       // blink updated nodes
       nodeUpdate.filter(function(d) {


### PR DESCRIPTION
It will blink the updated node so we'll know what changed:
![7lg1odcrow](https://cloud.githubusercontent.com/assets/7957859/19346800/f9552a06-914d-11e6-93d9-9f96c2792f67.gif)

Based on https://groups.google.com/forum/#!topic/d3-js/w11PXct8jPI/discussion and http://stackoverflow.com/questions/25222823/how-to-update-a-single-data-point-in-d3-without-touching-other-elements.

Related to https://github.com/zalmoxisus/redux-devtools-extension/issues/180
