### PR TITLE
Revert #5

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "d3": "^3.5.6",
     "d3tooltip": "^1.2.2",
     "deepmerge": "^0.2.10",
-    "fclone": "^1.0.8",
     "is-plain-object": "2.0.1",
     "json-pretty": "0.0.1",
     "map2tree": "^1.4.0",

--- a/src/charts/tree/sortAndSerialize.js
+++ b/src/charts/tree/sortAndSerialize.js
@@ -1,5 +1,4 @@
 import { is } from 'ramda'
-import fclone from 'fclone';
 
 function sortObject(obj, strict) {
   if (obj instanceof Array) {
@@ -22,5 +21,5 @@ function sortObject(obj, strict) {
 }
 
 export default function sortAndSerialize(obj) {
-  return JSON.stringify(sortObject(fclone(obj), true), undefined, 2)
+  return JSON.stringify(sortObject(obj, true), undefined, 2)
 }


### PR DESCRIPTION
Seems like fclone doesn’t handle all the cases and hangs sometimes.
Better just not to show objects with circular references at it was before.
