### PR TITLE
Less verbose data in the tooltip

### DIFF
--- a/src/charts/tree/utils.js
+++ b/src/charts/tree/utils.js
@@ -1,5 +1,5 @@
 import pretty from 'json-pretty';
-import { is, join, pipe, omit, replace } from 'ramda';
+import { is, join, pipe, replace } from 'ramda';
 import sortAndSerialize from './sortAndSerialize';
 
 export function collapseChildren(node) {
@@ -78,11 +78,9 @@ export function getTooltipString(node, i, { indentationSize = 4 }) {
   const json2html = pipe(sortAndSerialize, cr2br, spaces2nbsp);
 
   const children = node.children || node._children;
-  const tuple = omit(['parent', 'children', '_children', 'depth', 'id', 'x', 'x0', 'y', 'y0'], node);
 
-  if (children) {
-    tuple.childrenCount = children.length;
-  }
-
-  return json2html(tuple);
+  if (typeof node.value !== 'undefined') return json2html(node.value);
+  if (typeof node.object !== 'undefined') return json2html(node.object);
+  if (children && children.length) return 'childrenCount: ' +  children.length;
+  return 'empty';
 }


### PR DESCRIPTION
Additional data makes it difficult to investigate the state:

![uuntitled-1___66_7___layer_2__rgb_8____](https://cloud.githubusercontent.com/assets/7957859/20431530/23a53e1a-ada3-11e6-9ddb-c9aa8c4ae9f3.jpg)


<img width="599" alt="untitled-1___66_7___layer_2__rgb_8____" src="https://cloud.githubusercontent.com/assets/7957859/20431485/dc925512-ada2-11e6-9c3a-f6cca4e69134.png">
