### PR TITLE
Add opacity setting to text / node circle of falsey values

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Other options are listed below and have reasonable default values if you want to
 Option                    | Type     | Default     | Description
 --------------------------|----------|-------------|-------------------------------------------------------------------------
 `id`                      | String   | `'d3svg'`   | Sets the identifier of the SVG element —i.e your chart— that will be added to the DOM element you passed as first argument
-`style`                   | Object   | `{}`        | Sets the CSS style of the chart
+`style`                   | Object   | `{}`        | Sets specific CSS properties of the chart (see below) 
 `size`                    | Number   | `500`       | Sets size of the chart in pixels
 `aspectRatio`             | Float    | `1.0`       | Sets the chart height to `size * aspectRatio` and [viewBox](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/viewBox) in order to preserve the aspect ratio of the chart. [Great video](https://www.youtube.com/watch?v=FCOeMy7HrBc) if you want to learn more about how SVG works
 `widthBetweenNodesCoeff`  | Float    | `1.0`       | Alters the horizontal space between each node
@@ -68,7 +68,48 @@ Option                    | Type     | Default     | Description
 `rootKeyName`             | String   | `'state'`   | Sets the first node's name of the resulting tree structure. **Warning**: only works if you provide a `state` option
 `pushMethod`              | String   | `'push'`    | Sets the method that shall be used to add array children to the tree. **Warning**: only works if you provide a `state` option
 
+
+The following default styles are customizeable with the style option:
+
+```javascript
+style: {
+  node: {
+    colors: {
+      'default': '#ccc',
+      collapsed: 'lightsteelblue',
+      parent: 'white'
+    },
+    opacity: {
+      'default': 1.0,
+      empty: 0.75
+    },
+    radius: 7
+  },
+  text: {
+    colors: {
+      'default': 'black',
+      hover: 'skyblue'
+    },
+    opacity: {
+      'default': 1.0,
+      empty: 0.75
+    }
+  },
+  link: {
+    stroke: '#000',
+    fill: 'none'
+  }
+};
+
+```
+#### Special element types
+- `parent`: fill color for parent nodes
+- `collapsed`: fill color for nodeds collapsed by the user
+- `empty`: opacity for Falsey values (besides 0), helps data of interest stand out
+- `hover`: highlighted color of text when hovering to view a tooltip
+
 More to come...
+
 
 ## Bindings
 

--- a/src/charts/tree/tree.js
+++ b/src/charts/tree/tree.js
@@ -1,5 +1,5 @@
 import d3 from 'd3'
-import { isEmpty } from 'ramda'
+import { isEmpty, isNil } from 'ramda'
 import map2tree from 'map2tree'
 import deepmerge from 'deepmerge'
 import { getTooltipString, toggleChildren, visit, getNodeGroupByDepthCount } from './utils'
@@ -16,7 +16,11 @@ const defaultOptions = {
       colors: {
         'default': '#ccc',
         collapsed: 'lightsteelblue',
-        parent: 'white'
+        parent: 'white',
+      },
+      opacity: {
+        'default': 1.0,
+        empty: 1.0
       },
       radius: 7
     },
@@ -24,6 +28,10 @@ const defaultOptions = {
       colors: {
         'default': 'black',
         hover: 'skyblue'
+      },
+      opacity: {
+        'default': 1.0,
+        empty: 1.0
       }
     },
     link: {
@@ -188,7 +196,10 @@ export default function(DOMNode, options = {}) {
       let nodes = layout.nodes(data)
       let links = layout.links(nodes)
 
-      nodes.forEach(node => node.y = node.depth * (maxLabelLength * 7 * widthBetweenNodesCoeff))
+      nodes.forEach(node => {
+        node.y = node.depth * (maxLabelLength * 7 * widthBetweenNodesCoeff)
+        node.isEmpty = !node.children && (isEmpty(node.value) || isNil(node.value) || node.value === false);
+      })
 
       const nodePositions = nodes.map(n => ({
         parentId: n.parent && n.parent.id,
@@ -275,6 +286,7 @@ export default function(DOMNode, options = {}) {
       node.select('circle')
         .style({
           stroke: 'black',
+          opacity: d => d.isEmpty ? style.node.opacity.empty : style.node.opacity.default,
           'stroke-width': '1.5px',
           fill: d => d._children ? style.node.colors.collapsed : (d.children ? style.node.colors.parent : style.node.colors.default)
         })
@@ -292,7 +304,10 @@ export default function(DOMNode, options = {}) {
 
       // fade the text in and align it
       nodeUpdate.select('text')
-        .style('fill-opacity', 1)
+        .style({
+          'fill-opacity': 1,
+          opacity: d => d.isEmpty ? style.text.opacity.empty : style.text.opacity.default
+        })
         .attr({
           transform: function transform(d) {
             const x = (d.children || d._children ? -1 : 1) * (this.getBBox().width / 2 + style.node.radius + 5)

--- a/src/charts/tree/tree.js
+++ b/src/charts/tree/tree.js
@@ -1,9 +1,12 @@
 import d3 from 'd3'
-import { isEmpty, isNil } from 'ramda'
+import { isEmpty } from 'ramda'
 import map2tree from 'map2tree'
 import deepmerge from 'deepmerge'
-import { getTooltipString, toggleChildren, visit, getNodeGroupByDepthCount } from './utils'
 import d3tooltip from 'd3tooltip'
+import {
+  getTooltipString, toggleChildren, visit,
+  getNodeGroupByDepthCount, isNodeFalsey
+} from './utils'
 
 const defaultOptions = {
   state: undefined,
@@ -16,11 +19,11 @@ const defaultOptions = {
       colors: {
         'default': '#ccc',
         collapsed: 'lightsteelblue',
-        parent: 'white',
+        parent: 'white'
       },
       opacity: {
         'default': 1.0,
-        empty: 1.0
+        empty: 0.75
       },
       radius: 7
     },
@@ -31,7 +34,7 @@ const defaultOptions = {
       },
       opacity: {
         'default': 1.0,
-        empty: 1.0
+        empty: 0.75
       }
     },
     link: {
@@ -198,7 +201,7 @@ export default function(DOMNode, options = {}) {
 
       nodes.forEach(node => {
         node.y = node.depth * (maxLabelLength * 7 * widthBetweenNodesCoeff)
-        node.isEmpty = !node.children && (isEmpty(node.value) || isNil(node.value) || node.value === false);
+        node.isEmpty = isNodeFalsey(node);
       })
 
       const nodePositions = nodes.map(n => ({

--- a/src/charts/tree/utils.js
+++ b/src/charts/tree/utils.js
@@ -1,4 +1,5 @@
 import { is, join, pipe, replace } from 'ramda';
+import { isEmpty, isNil } from 'ramda'
 import sortAndSerialize from './sortAndSerialize';
 
 export function collapseChildren(node) {
@@ -82,4 +83,10 @@ export function getTooltipString(node, i, { indentationSize = 4 }) {
   if (typeof node.object !== 'undefined') return json2html(node.object);
   if (children && children.length) return 'childrenCount: ' + children.length;
   return 'empty';
+}
+
+export function isNodeFalsey({ children, value, object }) {
+  return !children &&
+    (isEmpty(value) || isNil(value) || value === false) &&
+    (isEmpty(object) || isNil(object));
 }


### PR DESCRIPTION
Added a couple of styling options to apply opacity values to null/empty/undefined values.  Defaults are 1.0 opacity for all nodes which can be changed with supplying property to the chart component as with other styling modifications.

![image](https://user-images.githubusercontent.com/3154616/40633243-faefc324-62b3-11e8-9c5b-dc53a0903c45.png)
